### PR TITLE
Update Readme and Debian version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # A very simple git server to deploy configuration
 
-FROM debian:jessie
+FROM debian:stretch
 MAINTAINER Jean-Marc Lagace <jean-marc@m2i3.com>
 
 RUN apt-get update && apt-get install -y git-daemon-run && apt-get clean && apt-get autoclean
@@ -17,4 +17,3 @@ EXPOSE 9418
 
 # Define default command.
 CMD ["/start.sh"]
-

--- a/README.md
+++ b/README.md
@@ -1,12 +1,44 @@
-# A very simple Git Daemon to simply transferring files and configuration 
+# A very simple Git Daemon to simply transfer files and configuration
+
+## Use
+
+Build the image:
+
+```
+make
+```
 
 How to use it:
 
-docker run -d -p 9418 m2i3/git-serve 
+```
+docker run -d -p 9418:9418 m2i3/git-serve
+```
 
-To clone from it:
+To clone from the default repository and start working:
 
-clone git://accessibleip:accessibleport/ ./localpath
+```
+git clone git://<accessibleip>:<accessibleport/> ./localpath
+```
+
+e.g.
+
+```
+git clone git://localhost:9418/ ./myfirstrepo
+```
+
+Since the default git serve port is mapped, using the port in clone or push/pull commands is optional.
+
+We can also push an existing repository, on localhost like so:
+
+```
+git push git://localhost/
+```
+
+## Extend
+
+Git repositories are created in a docker volume.
+
+`./start.sh` Gets run as default command in the container. This creates a single repository out of the box. Modify if you want more, or add them by hand to the volume.
 
 ## Notes
 


### PR DESCRIPTION
Hi,

it worked out of the box, even after four years, thanks! Debian version has just been updated in July, so changed the Dockerfile. `docker run -p` now requires the port twice, otherwise exposes on a random port to the outside.